### PR TITLE
Add custom keybindings to settings

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -67,6 +67,19 @@
         </div>
 
         <div class="setting-group">
+            <h2>Custom Keybindings</h2>
+            <div>
+                <label for="copyKeybinding">Copy Keybinding:</label>
+                <input type="text" id="copyKeybinding" placeholder="Enter copy keybinding">
+            </div>
+            <div>
+                <label for="pasteKeybinding">Paste Keybinding:</label>
+                <input type="text" id="pasteKeybinding" placeholder="Enter paste keybinding">
+            </div>
+            <button onclick="saveKeybindings()">Save Keybindings</button>
+        </div>
+
+        <div class="setting-group">
             <h2>Updates</h2>
             <div>
                 <p>Current version: <span id="currentVersion"></span></p>
@@ -171,6 +184,7 @@
             await loadSettings();
             await loadPreferences();
             await setupUpdateCheck(); // Add this line
+            await loadKeybindings(); // Add this line
         });
 
         window.addEventListener('DOMContentLoaded', loadCurrentSettings);
@@ -199,6 +213,22 @@
         document.getElementById('updateButton').addEventListener('click', () => {
             ipcRenderer.send('startUpdate');
         });
+
+        // Add function to load custom keybindings
+        async function loadKeybindings() {
+            const settings = await ipcRenderer.invoke('getSettings');
+            document.getElementById('copyKeybinding').value = settings.keybindings.copy;
+            document.getElementById('pasteKeybinding').value = settings.keybindings.paste;
+        }
+
+        // Add function to save custom keybindings
+        async function saveKeybindings() {
+            const copyKeybinding = document.getElementById('copyKeybinding').value;
+            const pasteKeybinding = document.getElementById('pasteKeybinding').value;
+            const keybindings = { copy: copyKeybinding, paste: pasteKeybinding };
+            await ipcRenderer.invoke('saveCustomKeybindings', keybindings);
+            alert('Keybindings saved successfully!');
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #3

Add support for custom keybindings.

* **main.js**
  - Add IPC handler to save custom keybindings to settings.
  - Add function to register custom keybindings from settings.
  - Call function to register custom keybindings on app ready.
  - Modify existing IPC handler to register custom keybindings after saving settings.

* **settings.html**
  - Add input fields for custom keybindings in preferences section.
  - Add function to load custom keybindings from settings on page load.
  - Add function to save custom keybindings to settings.
  - Add button to save custom keybindings.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Crossy-Clipboard/crossy-electron/issues/3?shareId=XXXX-XXXX-XXXX-XXXX).